### PR TITLE
fix: decompress panic

### DIFF
--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -192,7 +192,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let challenges =
             self.get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);
@@ -217,7 +217,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             &verifier_data.circuit_digest,
             common_data,
         )?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);


### PR DESCRIPTION
The decompress method panics when the public inputs are invalid because it derives query indices from them and uses them to access a HashMap with the index operator.
By using the `get` method we return an error instead.